### PR TITLE
feat: add disableHeadingRequirement and disableToc options to document node

### DIFF
--- a/src/IdentityTransformer.ts
+++ b/src/IdentityTransformer.ts
@@ -1227,6 +1227,12 @@ export class IdentityTransformer {
     if (node.keywords) {
       result.keywords = node.keywords;
     }
+    if (node.disableHeadingRequirement != null) {
+      result.disableHeadingRequirement = node.disableHeadingRequirement;
+    }
+    if (node.disableToc != null) {
+      result.disableToc = node.disableToc;
+    }
     return result;
   }
   async transform(node: DocumentNode): Promise<DocumentNode> {

--- a/src/__tests__/IdentityTransformer.test.ts
+++ b/src/__tests__/IdentityTransformer.test.ts
@@ -282,6 +282,8 @@ describe('IdentityTransformer', () => {
       url: "/test",
       hidden: true,
       noindex: true,
+      disableHeadingRequirement: true,
+      disableToc: true,
       author: "Test Author",
       description: "A test document",
       image: "https://example.com/og.png",
@@ -311,6 +313,47 @@ describe('IdentityTransformer', () => {
 
     const result = await new IdentityTransformer().transform(doc);
     expect(result).toEqual(doc);
+  });
+
+  test('does not add disableHeadingRequirement or disableToc when not in source', async () => {
+    const doc: DocumentNode = {
+      type: "document",
+      title: "Test",
+      url: "/test",
+      content: [{ type: "text", text: "Content" }],
+    };
+
+    const result = await new IdentityTransformer().transform(doc);
+    expect("disableHeadingRequirement" in result).toBe(false);
+    expect("disableToc" in result).toBe(false);
+  });
+
+  test('preserves disableHeadingRequirement independently', async () => {
+    const doc: DocumentNode = {
+      type: "document",
+      title: "Test",
+      url: "/test",
+      disableHeadingRequirement: true,
+      content: [{ type: "text", text: "Content" }],
+    };
+
+    const result = await new IdentityTransformer().transform(doc);
+    expect(result.disableHeadingRequirement).toBe(true);
+    expect("disableToc" in result).toBe(false);
+  });
+
+  test('preserves disableToc independently', async () => {
+    const doc: DocumentNode = {
+      type: "document",
+      title: "Test",
+      url: "/test",
+      disableToc: true,
+      content: [{ type: "text", text: "Content" }],
+    };
+
+    const result = await new IdentityTransformer().transform(doc);
+    expect("disableHeadingRequirement" in result).toBe(false);
+    expect(result.disableToc).toBe(true);
   });
 
   test('preserves embed with imagePreview', async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -458,6 +458,8 @@ export type Node =
 export interface DocumentMeta {
   hidden?: boolean;
   noindex?: boolean;
+  disableHeadingRequirement?: boolean;
+  disableToc?: boolean;
   title: string;
   author?: string;
   description?: string;


### PR DESCRIPTION
## Summary
- Adds `disableHeadingRequirement?: boolean` to `DocumentMeta` — allows renderers to skip mandatory heading SEO checks
- Adds `disableToc?: boolean` to `DocumentMeta` — allows renderers to skip table of contents generation
- Both flags are preserved through `IdentityTransformer` and only present when set (no undefined leakage)
- 3 new tests plus updated existing document meta test

Fixes #15

## Test plan
- [x] All 47 tests pass (`bun test`)
- [x] Both flags preserved when set together (existing meta test updated)
- [x] Each flag preserved independently
- [x] Neither flag added when absent from source document