### PR TITLE
feat: add badge node support

### DIFF
--- a/src/IdentityTransformer.ts
+++ b/src/IdentityTransformer.ts
@@ -2,6 +2,7 @@ import type {
   AccordionGroupNode,
   AccordionTabNode,
   ArrayNode,
+  BadgeNode,
   BlockNode,
   BlockQuoteNode,
   BoldNode,
@@ -86,6 +87,15 @@ export class IdentityTransformer {
       }
     }
     return children;
+  }
+  protected async badge(node: BadgeNode): Promise<Node | null> {
+    const result: BadgeNode = {
+      type: "badge",
+      url: node.url,
+      alt: node.alt,
+    };
+    if (node.id != null) {result.id = node.id;}
+    return result;
   }
   protected async block(node: BlockNode): Promise<Node | null> {
     await this.beforeBlock();
@@ -1043,6 +1053,8 @@ export class IdentityTransformer {
     }
     try {
       switch (node.type) {
+        case "badge":
+          return await this.badge(node);
         case "block":
           return await this.block(node);
         case "block-quote":

--- a/src/NodeVisitor.ts
+++ b/src/NodeVisitor.ts
@@ -1,5 +1,6 @@
 import type {
   ArrayNode,
+  BadgeNode,
   BlockNode,
   BlockQuoteNode,
   BoldNode,
@@ -68,6 +69,8 @@ export class NodeVisitor {
     for (const child of nodes) {
       this.choose(child);
     }
+  }
+  protected badge(_node: BadgeNode): void {
   }
   protected block(node: BlockNode): void {
     this.beforeBlock();
@@ -359,6 +362,8 @@ export class NodeVisitor {
     }
     try {
       switch (node.type) {
+        case "badge":
+          return this.badge(node);
         case "block":
           return this.block(node);
         case "block-quote":

--- a/src/__tests__/IdentityTransformer.test.ts
+++ b/src/__tests__/IdentityTransformer.test.ts
@@ -10,6 +10,63 @@ describe('IdentityTransformer', () => {
     ).toEqual(ExampleDocument);
   });
 
+  test('preserves badge node', async () => {
+    const doc: DocumentNode = {
+      type: "document",
+      title: "Test",
+      url: "/test",
+      content: [
+        {
+          type: "badge",
+          url: "https://img.shields.io/github/actions/workflow/status/cendyne/document-ir/build.yaml",
+          alt: "Build Status",
+        },
+      ],
+    };
+
+    const result = await new IdentityTransformer().transform(doc);
+    expect(result).toEqual(doc);
+  });
+
+  test('preserves badge node with id', async () => {
+    const doc: DocumentNode = {
+      type: "document",
+      title: "Test",
+      url: "/test",
+      content: [
+        {
+          type: "badge",
+          id: "badge1",
+          url: "https://img.shields.io/badge/license-MIT-blue",
+          alt: "License",
+        },
+      ],
+    };
+
+    const result = await new IdentityTransformer().transform(doc);
+    expect(result).toEqual(doc);
+  });
+
+  test('does not add id to badge when source has no id', async () => {
+    const doc: DocumentNode = {
+      type: "document",
+      title: "Test",
+      url: "/test",
+      content: [
+        {
+          type: "badge",
+          url: "https://img.shields.io/badge/test-passing-green",
+          alt: "Test",
+        },
+      ],
+    };
+
+    const result = await new IdentityTransformer().transform(doc);
+    const node = result.content[0]!;
+    expect(node.type).toBe("badge");
+    expect(Object.keys(node).sort()).toEqual(["alt", "type", "url"]);
+  });
+
   test('preserves all link attributes', async () => {
     const doc: DocumentNode = {
       type: "document",

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,11 @@ export interface ArrayNode extends NodeIdentity {
   type: "array";
   content: Node[];
 }
+export interface BadgeNode extends NodeIdentity {
+  type: "badge";
+  url: string;
+  alt: string;
+}
 export interface BlockNode extends NodeIdentity {
   type: "block";
   content: Node[];
@@ -399,6 +404,7 @@ export interface TableOfContentsNode extends NodeIdentity {
 export type Node =
   | AccordionGroupNode
   | ArrayNode
+  | BadgeNode
   | BlockNode
   | BlockQuoteNode
   | BoldNode


### PR DESCRIPTION
## Summary
- Adds `BadgeNode` (type `"badge"`) — an inline image node with `url` and `alt`, similar to `EmojiNode`
- Intended for status badges (e.g. shields.io) where dimensions are unknown and constrained by CSS to line height/content width
- Wired through `types.ts`, `NodeVisitor`, `IdentityTransformer`, and the `Node` union type
- 3 new tests covering identity transformation, id preservation, and no undefined attribute leakage

Fixes #16

## Test plan
- [x] All 50 tests pass (`bun test`)
- [x] Badge preserves url and alt through identity transformation
- [x] Badge preserves id when present
- [x] No undefined optional attributes leak onto badge node