### PR TITLE
fix: preserve whitespace in code nodes for whitespace transformers

### DIFF
--- a/src/WhitespaceStretchingTransformer.ts
+++ b/src/WhitespaceStretchingTransformer.ts
@@ -1,5 +1,5 @@
 import { IdentityTransformer } from "./IdentityTransformer.ts";
-import type { DocumentNode, Node, TextNode } from "./types.ts";
+import type { CodeNode, DocumentNode, Node, TextNode } from "./types.ts";
 
 interface BlockInfo {
   type: "_block";
@@ -107,6 +107,16 @@ export class WhitespaceStretchingTransformer extends IdentityTransformer {
         }
       }
     }
+  }
+  protected override async code(node: CodeNode): Promise<Node | null> {
+    const result: CodeNode = {
+      type: "code",
+      content: node.content,
+    };
+    if (node.diff != null) {result.diff = node.diff;}
+    if (node.lineNumbers != null) {result.lineNumbers = node.lineNumbers;}
+    if (node.id != null) {result.id = node.id;}
+    return result;
   }
   protected override async text(node: TextNode): Promise<Node | null> {
     const replacement: TextNode = {

--- a/src/WhitespaceTransformer.ts
+++ b/src/WhitespaceTransformer.ts
@@ -1,5 +1,5 @@
 import { IdentityTransformer } from "./IdentityTransformer.ts";
-import type { DocumentNode, Node, TextNode } from "./types.ts";
+import type { CodeNode, DocumentNode, Node, TextNode } from "./types.ts";
 
 class RemoveEmptyTextTransformer extends IdentityTransformer {
   protected override async text(node: TextNode): Promise<Node | null> {
@@ -50,6 +50,16 @@ export class WhitespaceTransformer extends IdentityTransformer {
       this.lastText = null;
     }
     this.stripWhitespace = true;
+  }
+  protected override async code(node: CodeNode): Promise<Node | null> {
+    const result: CodeNode = {
+      type: "code",
+      content: node.content,
+    };
+    if (node.diff != null) {result.diff = node.diff;}
+    if (node.lineNumbers != null) {result.lineNumbers = node.lineNumbers;}
+    if (node.id != null) {result.id = node.id;}
+    return result;
   }
   protected override async beforeBlock(): Promise<void> {
     this.stripLastText();

--- a/src/__tests__/WhitespaceStretchingTransformer.test.ts
+++ b/src/__tests__/WhitespaceStretchingTransformer.test.ts
@@ -127,4 +127,57 @@ describe('WhitespaceStretchingTransformer', () => {
       await new WhitespaceStretchingTransformer().transform(ExpectedDocument),
     ).toEqual(ExpectedDocument);
   });
+
+  test('preserves whitespace in inline code', async () => {
+    const InputDocument: DocumentNode = {
+      ...ExampleDocument,
+      content: [
+        {
+          type: "text",
+          text: "see",
+        },
+        {
+          type: "code",
+          content: [
+            {
+              type: "text",
+              text: "  foo  bar  ",
+            },
+          ],
+        },
+        {
+          type: "text",
+          text: "for details",
+        },
+      ],
+    };
+
+    const result = await new WhitespaceStretchingTransformer().transform(InputDocument);
+    const codeNode = result.content[1] as any;
+    expect(codeNode.content[0].text).toEqual("  foo  bar  ");
+  });
+
+  test('preserves whitespace in code block', async () => {
+    const InputDocument: DocumentNode = {
+      ...ExampleDocument,
+      content: [
+        {
+          type: "code-block",
+          fileName: "test.js",
+          content: {
+            type: "code",
+            content: [
+              {
+                type: "text",
+                text: "function foo() {\n  return  bar;\n}",
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const result = await new WhitespaceStretchingTransformer().transform(InputDocument);
+    expect(result).toEqual(InputDocument);
+  });
 });

--- a/src/__tests__/WhitespaceTransformer.test.ts
+++ b/src/__tests__/WhitespaceTransformer.test.ts
@@ -115,4 +115,110 @@ describe('WhitespaceTransformer', () => {
       await new WhitespaceTransformer().transform(ExpectedDocument),
     ).toEqual(ExpectedDocument);
   });
+
+  test('preserves whitespace in inline code', async () => {
+    const InputDocument: DocumentNode = {
+      ...ExampleDocument,
+      content: [
+        {
+          type: "text",
+          text: " see ",
+        },
+        {
+          type: "code",
+          content: [
+            {
+              type: "text",
+              text: "  foo  bar  ",
+            },
+          ],
+        },
+        {
+          type: "text",
+          text: " for details ",
+        },
+      ],
+    };
+
+    const ExpectedDocument: DocumentNode = {
+      ...ExampleDocument,
+      content: [
+        {
+          type: "text",
+          text: "see ",
+        },
+        {
+          type: "code",
+          content: [
+            {
+              type: "text",
+              text: "  foo  bar  ",
+            },
+          ],
+        },
+        {
+          type: "text",
+          text: "for details",
+        },
+      ],
+    };
+
+    expect(
+      await new WhitespaceTransformer().transform(InputDocument),
+    ).toEqual(ExpectedDocument);
+  });
+
+  test('preserves whitespace in code block', async () => {
+    const InputDocument: DocumentNode = {
+      ...ExampleDocument,
+      content: [
+        {
+          type: "code-block",
+          fileName: "test.js",
+          content: {
+            type: "code",
+            content: [
+              {
+                type: "text",
+                text: "function foo() {\n  return  bar;\n}",
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const result = await new WhitespaceTransformer().transform(InputDocument);
+    expect(result).toEqual(InputDocument);
+  });
+
+  test('preserves whitespace in code group', async () => {
+    const InputDocument: DocumentNode = {
+      ...ExampleDocument,
+      content: [
+        {
+          type: "code-group",
+          tabs: [
+            {
+              type: "code-group-tab",
+              header: [{ type: "text", text: "JS" }],
+              content: {
+                type: "code",
+                content: [
+                  {
+                    type: "text",
+                    text: "const  x\n\t= 1;",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = await new WhitespaceTransformer().transform(InputDocument);
+    const tab = (result.content[0] as any).tabs[0];
+    expect(tab.content.content[0].text).toEqual("const  x\n\t= 1;");
+  });
 });


### PR DESCRIPTION
## Summary
- Overrides `code()` in `WhitespaceTransformer` and `WhitespaceStretchingTransformer` to pass through code node content without visiting children, preventing whitespace collapsing/stretching from corrupting code content
- The `code()` method in `IdentityTransformer` calls `chooseChildren()` on code content, which dispatches to `text()` — both transformers override `text()` in ways that modify whitespace, which is incorrect for code
- `formattedText()` was already fine since it copies `node.text` directly without descending into children

Fixes #21

## Test plan
- [x] Added test for inline `code` node preservation in `WhitespaceTransformer`
- [x] Added test for `code-block` node preservation in `WhitespaceTransformer`
- [x] Added test for `code-group` node preservation in `WhitespaceTransformer`
- [x] Added test for inline `code` node preservation in `WhitespaceStretchingTransformer`
- [x] Added test for `code-block` node preservation in `WhitespaceStretchingTransformer`
- [x] All 55 tests pass, type-check passes