### PR TITLE
fix: add language property to CodeNode and fix dropped optional attributes

### DIFF
--- a/src/IdentityTransformer.ts
+++ b/src/IdentityTransformer.ts
@@ -170,6 +170,7 @@ export class IdentityTransformer {
       type: "code",
       content,
     };
+    if (node.language != null) {result.language = node.language;}
     if (node.diff != null) {result.diff = node.diff;}
     if (node.lineNumbers != null) {result.lineNumbers = node.lineNumbers;}
     if (node.id != null) {result.id = node.id;}
@@ -411,8 +412,8 @@ export class IdentityTransformer {
     const result: FormattedTextNode = {
       type: "formatted-text",
       text: node.text || "",
-      language: node.language,
     };
+    if (node.language != null) {result.language = node.language;}
     if (node.id != null) {result.id = node.id;}
     return result;
   }
@@ -600,9 +601,11 @@ export class IdentityTransformer {
       icon: node.icon,
       name: node.name,
       content,
-      url: node.url,
     };
     if (node.id != null) {result.id = node.id;}
+    if (node.url) {
+      result.url = node.url;
+    }
     if (node.orientation) {
       result.orientation = node.orientation;
     }
@@ -936,8 +939,8 @@ export class IdentityTransformer {
       attribution,
       header,
       media,
-      original: node.original,
     };
+    if (node.original) {result.original = node.original;}
     if (node.id != null) {result.id = node.id;}
     return result;
   }

--- a/src/WhitespaceStretchingTransformer.ts
+++ b/src/WhitespaceStretchingTransformer.ts
@@ -113,6 +113,7 @@ export class WhitespaceStretchingTransformer extends IdentityTransformer {
       type: "code",
       content: node.content,
     };
+    if (node.language != null) {result.language = node.language;}
     if (node.diff != null) {result.diff = node.diff;}
     if (node.lineNumbers != null) {result.lineNumbers = node.lineNumbers;}
     if (node.id != null) {result.id = node.id;}

--- a/src/WhitespaceTransformer.ts
+++ b/src/WhitespaceTransformer.ts
@@ -56,6 +56,7 @@ export class WhitespaceTransformer extends IdentityTransformer {
       type: "code",
       content: node.content,
     };
+    if (node.language != null) {result.language = node.language;}
     if (node.diff != null) {result.diff = node.diff;}
     if (node.lineNumbers != null) {result.lineNumbers = node.lineNumbers;}
     if (node.id != null) {result.id = node.id;}

--- a/src/__tests__/IdentityTransformer.test.ts
+++ b/src/__tests__/IdentityTransformer.test.ts
@@ -746,6 +746,127 @@ describe('IdentityTransformer', () => {
     expect(Object.keys(node).sort()).toEqual(["type"]);
   });
 
+  test('preserves code node with language', async () => {
+    const doc: DocumentNode = {
+      type: "document",
+      title: "Test",
+      url: "/test",
+      content: [
+        {
+          type: "code",
+          language: "javascript",
+          content: [{ type: "text", text: "const x = 1;" }],
+        },
+      ],
+    };
+
+    const result = await new IdentityTransformer().transform(doc);
+    expect(result).toEqual(doc);
+  });
+
+  test('preserves code-block with language on inner code node', async () => {
+    const doc: DocumentNode = {
+      type: "document",
+      title: "Test",
+      url: "/test",
+      content: [
+        {
+          type: "code-block",
+          fileName: "example.ts",
+          content: {
+            type: "code",
+            language: "typescript",
+            content: [{ type: "text", text: "const x: number = 1;" }],
+          },
+        },
+      ],
+    };
+
+    const result = await new IdentityTransformer().transform(doc);
+    expect(result).toEqual(doc);
+  });
+
+  test('does not add language to code node when source has no language', async () => {
+    const doc: DocumentNode = {
+      type: "document",
+      title: "Test",
+      url: "/test",
+      content: [
+        {
+          type: "code",
+          content: [{ type: "text", text: "x = 1" }],
+        },
+      ],
+    };
+
+    const result = await new IdentityTransformer().transform(doc);
+    const node = result.content[0]!;
+    expect(node.type).toBe("code");
+    expect("language" in node).toBe(false);
+  });
+
+  test('does not add language to formatted-text when source has no language', async () => {
+    const doc: DocumentNode = {
+      type: "document",
+      title: "Test",
+      url: "/test",
+      content: [
+        {
+          type: "formatted-text",
+          text: "some code",
+        },
+      ],
+    };
+
+    const result = await new IdentityTransformer().transform(doc);
+    const node = result.content[0]!;
+    expect(node.type).toBe("formatted-text");
+    expect("language" in node).toBe(false);
+  });
+
+  test('does not add url to quote when source has no url', async () => {
+    const doc: DocumentNode = {
+      type: "document",
+      title: "Test",
+      url: "/test",
+      content: [
+        {
+          type: "quote",
+          name: "Author",
+          icon: "https://example.com/avatar.png",
+          content: [{ type: "text", text: "A quote" }],
+        },
+      ],
+    };
+
+    const result = await new IdentityTransformer().transform(doc);
+    const node = result.content[0]!;
+    expect(node.type).toBe("quote");
+    expect("url" in node).toBe(false);
+  });
+
+  test('does not add original to card when source has no original', async () => {
+    const doc: DocumentNode = {
+      type: "document",
+      title: "Test",
+      url: "/test",
+      content: [
+        {
+          type: "card",
+          content: {
+            type: "card-content",
+            content: [{ type: "text", text: "Card body" }],
+          },
+        },
+      ],
+    };
+
+    const result = await new IdentityTransformer().transform(doc);
+    const node = result.content[0]!;
+    expect(node.type).toBe("card");
+    expect("original" in node).toBe(false);
+  });
+
   test('does not add undefined optional attributes to figure-image', async () => {
     const doc: DocumentNode = {
       type: "document",

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,7 @@ export interface CenterNode extends NodeIdentity {
 export interface CodeNode extends NodeIdentity {
   type: "code";
   content: Node[];
+  language?: string;
   diff?: boolean;
   lineNumbers?: boolean;
 }


### PR DESCRIPTION
## Summary
- Adds `language?: string` to `CodeNode` type definition and copies it in `IdentityTransformer.code()`, `WhitespaceTransformer.code()`, and `WhitespaceStretchingTransformer.code()`
- Fixes `FormattedTextNode.language`, `QuoteNode.url`, and `CardNode.original` being unconditionally set — these previously leaked `undefined` keys when the source node didn't have them, inconsistent with the conditional pattern used everywhere else
- Full audit of all 60+ node types confirmed no other dropped attributes

Fixes #24

## Test plan
- [x] Added test: code node with `language` is preserved through transform
- [x] Added test: code-block with `language` on inner code node is preserved
- [x] Added test: code node without `language` does not get `language` key added
- [x] Added test: formatted-text without `language` does not get `language` key added
- [x] Added test: quote without `url` does not get `url` key added
- [x] Added test: card without `original` does not get `original` key added
- [x] All 61 tests pass, type-check passes